### PR TITLE
Added check to prevent commands being populated every time.

### DIFF
--- a/main.js
+++ b/main.js
@@ -17,8 +17,17 @@ var input = document.querySelector('#leInput'),
     };
 
 function triggeredInput() {
-  setTimeout(function(){
+  setTimeout(function() {
     var file = input.value;
+    // If a command has already been given, ignore
+    var extAlreadyGiven = false;
+    Object.keys(commands).forEach(function(ext) {
+        if (input.value.indexOf(commands[ext]) > -1) extAlreadyGiven = true;
+    });
+
+    if (extAlreadyGiven) return;
+
+    // Find the command for given extension
     Object.keys(commands).forEach(function(ext) {
       if(file.substr(-ext.length) == ext) {
         input.value = commands[ext] + ' ' + file;


### PR DESCRIPTION
If `foo.tar.gz` was entered, the extraction command would be added anytime return was pressed and would result in something like this: `tar xfvz tar xfvz tar xfvz tar xfvz tar xfvz foo.tar.gz`. This adds a check to prevent that from happening if an extraction command string is found in the input box.
